### PR TITLE
Added Android implementation for 'read contacts' and 'write contacts' permissions

### DIFF
--- a/android/src/main/java/com/ethras/simplepermissions/SimplePermissionsPlugin.java
+++ b/android/src/main/java/com/ethras/simplepermissions/SimplePermissionsPlugin.java
@@ -102,6 +102,12 @@ public class SimplePermissionsPlugin implements MethodCallHandler, PluginRegistr
             case "ALWAYS_LOCATION":
                 res = Manifest.permission.ACCESS_FINE_LOCATION;
                 break;
+            case "READ_CONTACTS":
+                res = Manifest.permission.READ_CONTACTS;
+                break;
+            case "WRITE_CONTACTS":
+                res = Manifest.permission.WRITE_CONTACTS;
+                break;
             default:
                 res = "ERROR";
                 break;

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,8 @@
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.READ_CONTACTS"/>
+    <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
 
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.

--- a/lib/simple_permissions.dart
+++ b/lib/simple_permissions.dart
@@ -57,7 +57,9 @@ enum Permission {
   AccessCoarseLocation,
   AccessFineLocation,
   WhenInUseLocation,
-  AlwaysLocation
+  AlwaysLocation,
+  ReadContacts,
+  WriteContacts
 }
 
 /// Permissions status enum (iOs)
@@ -87,8 +89,12 @@ String getPermissionString(Permission permission) {
     case Permission.AlwaysLocation:
       res = "ALWAYS_LOCATION";
       break;
-    default:
-      res = "ERROR";
+    case Permission.ReadContacts:
+      res = "READ_CONTACTS";
+      break;
+    case Permission.WriteContacts:
+      res = "WRITE_CONTACTS";
+      break;
   }
   return res;
 }


### PR DESCRIPTION
FYI, I've removed the "default" case for the switch in `getPermissionString(Permission permission` because without the default in place, the IDE will show error when adding permissions to the enum, thus saving a deployment cycle (I had missed that and I saw "ERROR" when running the example). Feel free to re-add it if you disagree ;-)