### PR TITLE
Do not fall through on getPermissionStatus

### DIFF
--- a/android/src/main/java/com/ethras/simplepermissions/SimplePermissionsPlugin.java
+++ b/android/src/main/java/com/ethras/simplepermissions/SimplePermissionsPlugin.java
@@ -50,6 +50,7 @@ public class SimplePermissionsPlugin implements MethodCallHandler, PluginRegistr
                 permission = call.argument("permission");
                 int value = checkPermission(permission) ? 3 : 2;
                 result.success(value);
+                break;
             case "checkPermission":
                 permission = call.argument("permission");
                 result.success(checkPermission(permission));


### PR DESCRIPTION
when "getPermissionStatus" is called on android, it falls through to "checkPermission". The same result object is submitted multiple times with result.success which fills the log with error messages.